### PR TITLE
Update game / tag chips look & feel

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "**/*.css"
   ],
   "scripts": {
+    "start": "npm run dev",
     "dev": "next dev",
     "build": "node scripts/update-barrels.mjs && tsup && node scripts/fix-use-client.mjs && node scripts/fix-dts-extensions.mjs",
     "prepublishOnly": "npm run build",

--- a/src/components/PlayerPage/PlayerTagsCard.tsx
+++ b/src/components/PlayerPage/PlayerTagsCard.tsx
@@ -5,6 +5,7 @@ import Grid from "@mui/material/Grid"
 import Card from "@mui/material/Card"
 import CardHeader from "@mui/material/CardHeader"
 import CardContent from "@mui/material/CardContent"
+import Chip from "@/components/shared/Chip";
 
 export default function PlayerTagsCard(props : {PlayerTags: Tag[]}) {
     return (
@@ -28,30 +29,9 @@ export default function PlayerTagsCard(props : {PlayerTags: Tag[]}) {
 }
 
 const renderLabels = (tags:Tag[]) => {
-
   return (
-  <div className="mt-2 flex flex-wrap gap-2">
-    { tags.map((tag) => generateLabel(tag))}
-  </div>
-)
-}
-
-const generateLabel = (tag:Tag) => {
-
-  let color = "#bfbcbb"
-  if (tag.color) color = tag.color
-
-    return (
-      <span
-        key={tag.id}
-        className="inline-block text-sm px-3 py-1 rounded-full outline-black outline-2 font-outlined"
-        style={{background:color,
-          color:"white",
-          textShadow: "black 0.2em 0.2em 0.4em"
-        }}
-      >
-      {tag.label}
-      </span>
-    )
-
+    <div className="mt-2 flex flex-wrap gap-2">
+      { tags.map((tag) => <Chip key={tag.id} tag={tag} />) }
+    </div>
+  )
 }

--- a/src/components/shared/Chip.tsx
+++ b/src/components/shared/Chip.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import {Tag} from "@/types/tag";
+
+export default function Chip({ tag, removeCallback }: { tag: Tag, removeCallback?: (tagId: number) => void }) {
+  const color = tag.color ?? "#bfbcbb";
+  return (
+      <>
+      <span
+          key={tag.id}
+          className="inline-block text-sm px-3 py-1 rounded-full border-2 font-outlined text-white m-0.5 font-stretch-105% font-sans"
+          style={{
+            borderColor: `color-mix(in srgb, ${color}, black 50%)`,
+            background: `linear-gradient(160deg, color-mix(in srgb, ${color}, white 10%) 0%, color-mix(in srgb, ${color}, black 60%) 100%)`,
+            textShadow: "black 1.5px 1px 1.5px",
+            filter: `drop-shadow(2px 2px 1.5px color-mix(in srgb, ${color}, black 80%))`
+          }}
+      >
+          {tag.label}
+          {removeCallback && (
+              <button
+                  type="button"
+                  onClick={() => removeCallback(tag.id)}
+                  className="ml-2 text-white hover:text-red-700 focus:outline-none pl-0.5 pr-1 cursor-pointer hover:bg-white rounded-full"
+                  style={{
+                    textShadow: "black 1px 1px 1px"
+                  }}
+              >
+                X
+              </button>
+          )}
+    </span>
+    </>
+  )
+
+}

--- a/src/components/shared/TagComponents.tsx
+++ b/src/components/shared/TagComponents.tsx
@@ -2,23 +2,11 @@
 
 import React from "react";
 import type { Tag } from "@/types/tag";
+import Chip from "@/components/shared/Chip";
 
 export function generateTagsDisplay(tag: Tag) {
     return (
-        <span
-            key={tag.id}
-            className="inline-block text-sm px-3 py-1 rounded-full outline-black outline-2 font-outlined"
-            style={{
-                marginTop:"6px",
-                marginRight: "6px",
-                marginBottom: "6px",
-                background: tag.color || '#bfbcbb',
-                color: "white",
-                textShadow: "black 0.2em 0.2em 0.4em"
-            }}
-        >
-            {tag.label}
-        </span>
+        <Chip tag={tag} key={tag.id} />
     )
 }
 

--- a/src/components/shared/TagEditor.tsx
+++ b/src/components/shared/TagEditor.tsx
@@ -9,6 +9,7 @@ import Grid from "@mui/material/Grid";
 import Popper, { PopperProps } from "@mui/material/Popper";
 import TextField from "@mui/material/TextField";
 import type { Tag } from "@/types/tag";
+import Chip from "@/components/shared/Chip";
 
 export interface TagEditorProps {
   title?: string;
@@ -47,24 +48,11 @@ export function TagEditor({
           <CardContent>
             <div className="mt-2 flex flex-wrap gap-2">
               {selectedTags.map((tag) => (
-                <span
+                <Chip
                   key={tag.id}
-                  className="inline-block text-sm px-3 py-1 rounded-full outline-black outline-2 font-outlined"
-                  style={{
-                    background: tag.color || "#bfbcbb",
-                    color: "white",
-                    textShadow: "black 0.2em 0.2em 0.4em",
-                  }}
-                >
-                  {tag.label}
-                  <button
-                    type="button"
-                    onClick={() => onToggleTag(tag.id)}
-                    className="ml-2 text-red-500 bg-white bg-opacity-50 rounded-full outline-black outline-2 font-outlined"
-                  >
-                    &times;
-                  </button>
-                </span>
+                  tag={tag}
+                  removeCallback={() => onToggleTag(tag.id)}
+                />
               ))}
             </div>
             <Grid container spacing={3}>


### PR DESCRIPTION
This PR makes a new Chip component to hold the various tag names, styles the font and font shadow for readability, and updates the chip border, background gradient, and shadow to be calculated based off of the base color

<img width="249" height="614" alt="image" src="https://github.com/user-attachments/assets/575bd987-5631-4e7f-936b-74d95e27f772" />
